### PR TITLE
fix: accès aux fichiers statiques avec pyinstaller

### DIFF
--- a/CuttableGrass.py
+++ b/CuttableGrass.py
@@ -1,7 +1,8 @@
+import os
 import pygame, math, random
 from globals import *
 
-leafSpriteSheet = pygame.image.load("assets/NinjaAdventure/FX/Particle/Grass.png")
+leafSpriteSheet = pygame.image.load(os.path.dirname(__file__) + "/assets/NinjaAdventure/FX/Particle/Grass.png")
 leafSpriteSize = (12, 13)
 leafSprites = [pygame.transform.scale(leafSpriteSheet.subsurface(pygame.Rect(leafSpriteSize[0] * x, leafSpriteSize[1] * 0, leafSpriteSize[0], leafSpriteSize[1])), (size[0], size[1])) for x in range(0, 6)]
 

--- a/Enemy.py
+++ b/Enemy.py
@@ -1,12 +1,13 @@
+import os
 from typing import Any
 import pygame, math, random
 from globals import *
 
 SQRT2 = math.sqrt(2)
 
-spriteSheetBeast = pygame.image.load("assets/NinjaAdventure/Actor/Monsters/Beast/Beast.png").convert_alpha()
-spriteSheetSlime = pygame.image.load("assets/NinjaAdventure/Actor/Monsters/Slime/Slime.png").convert_alpha()
-spriteSheetDeath = pygame.image.load("assets/NinjaAdventure/FX/Magic/Circle/SpriteSheetSpark.png").convert_alpha()
+spriteSheetBeast = pygame.image.load(os.path.dirname(__file__) + "/assets/NinjaAdventure/Actor/Monsters/Beast/Beast.png").convert_alpha()
+spriteSheetSlime = pygame.image.load(os.path.dirname(__file__) + "/assets/NinjaAdventure/Actor/Monsters/Slime/Slime.png").convert_alpha()
+spriteSheetDeath = pygame.image.load(os.path.dirname(__file__) + "/assets/NinjaAdventure/FX/Magic/Circle/SpriteSheetSpark.png").convert_alpha()
 spriteSize = mapTileSize.x
 deathSize = 32
 
@@ -61,8 +62,8 @@ class Enemy(pygame.sprite.Sprite):
         }
     }
     sounds = {
-            "hit": pygame.mixer.Sound("assets/NinjaAdventure/Sounds/Game/Hit.wav"),
-            "dead": pygame.mixer.Sound("assets/NinjaAdventure/Sounds/Game/Kill.wav")
+            "hit": pygame.mixer.Sound(os.path.dirname(__file__) + "/assets/NinjaAdventure/Sounds/Game/Hit.wav"),
+            "dead": pygame.mixer.Sound(os.path.dirname(__file__) + "/assets/NinjaAdventure/Sounds/Game/Kill.wav")
         }
     def __init__(self, pos, size, type, dead, groups):
         super().__init__(groups)

--- a/Item.py
+++ b/Item.py
@@ -1,14 +1,15 @@
+import os
 import pygame
 from globals import *
 
 class Item(pygame.sprite.Sprite):
     types = {
-        "potionHealth": pygame.transform.scale(pygame.image.load("assets/NinjaAdventure/Items/Potion/LifePot.png"), (size[0] / 2, size[1] / 2)),
-        "plantSpell": pygame.transform.scale(pygame.image.load("assets/NinjaAdventure/Items/Scroll/ScrollPlant.png"), (size[0] / 2, size[1] / 2)),
-        "heart": pygame.transform.scale(pygame.image.load("assets/NinjaAdventure/HUD/Heart.png").subsurface(pygame.rect.Rect(0, 0, 16, 16)), (size[0] / 2, size[1] / 2)),
-        "pickaxe": pygame.transform.scale(pygame.image.load("assets/NinjaAdventure/Items/Weapons/Pickaxe/Sprite.png"), (size[0] / 2, size[1] / 2)),
-        "axe": pygame.transform.scale(pygame.image.load("assets/NinjaAdventure/Items/Weapons/Axe/Sprite.png"), (size[0] / 2, size[1] / 2)),
-        "coin": pygame.transform.scale(pygame.image.load("assets/NinjaAdventure/Items/Treasure/GoldCoin.png"), (size[0] / 2, size[1] / 2)),
+        "potionHealth": pygame.transform.scale(pygame.image.load(os.path.dirname(__file__) + "/assets/NinjaAdventure/Items/Potion/LifePot.png"), (size[0] / 2, size[1] / 2)),
+        "plantSpell": pygame.transform.scale(pygame.image.load(os.path.dirname(__file__) + "/assets/NinjaAdventure/Items/Scroll/ScrollPlant.png"), (size[0] / 2, size[1] / 2)),
+        "heart": pygame.transform.scale(pygame.image.load(os.path.dirname(__file__) + "/assets/NinjaAdventure/HUD/Heart.png").subsurface(pygame.rect.Rect(0, 0, 16, 16)), (size[0] / 2, size[1] / 2)),
+        "pickaxe": pygame.transform.scale(pygame.image.load(os.path.dirname(__file__) + "/assets/NinjaAdventure/Items/Weapons/Pickaxe/Sprite.png"), (size[0] / 2, size[1] / 2)),
+        "axe": pygame.transform.scale(pygame.image.load(os.path.dirname(__file__) + "/assets/NinjaAdventure/Items/Weapons/Axe/Sprite.png"), (size[0] / 2, size[1] / 2)),
+        "coin": pygame.transform.scale(pygame.image.load(os.path.dirname(__file__) + "/assets/NinjaAdventure/Items/Treasure/GoldCoin.png"), (size[0] / 2, size[1] / 2)),
     }
     def __init__(self, pos, type, dead, groups, alreadyCentered=False, price=-1, amount=1, category=-1, initialVelocity=-1, rotation=-1):
         super().__init__(groups)

--- a/Menu.py
+++ b/Menu.py
@@ -1,9 +1,10 @@
+import os
 import pygame
 from pytmx.util_pygame import load_pygame
 from globals import *
 from inputs import *
 
-mainMenuMap = load_pygame("maps/MenuBackground.tmx")
+mainMenuMap = load_pygame(os.path.dirname(__file__) + "/maps/MenuBackground.tmx")
 
 class MainMenu:
     def __init__(self, windowSize):
@@ -12,8 +13,8 @@ class MainMenu:
             if hasattr(layer, "data"):
                 for x, y, surf in layer.tiles():
                     self.mainMenuBackground.blit(pygame.transform.scale(surf, size), (x * size[0], y * size[1]))
-        self.buttonImage = pygame.image.load("assets/NinjaAdventure/HUD/Dialog/DialogueBoxSimple.png")
-        self.buttonImageHovered = pygame.image.load("assets/NinjaAdventure/HUD/Dialog/DialogBox.png")
+        self.buttonImage = pygame.image.load(os.path.dirname(__file__) + "/assets/NinjaAdventure/HUD/Dialog/DialogueBoxSimple.png")
+        self.buttonImageHovered = pygame.image.load(os.path.dirname(__file__) + "/assets/NinjaAdventure/HUD/Dialog/DialogBox.png")
 
         self.buttons = {
             "startGame": {"pos": (0, 0), "size": (1000, 200), "neighborDown": "quitGame", "text": "Start Game!"},
@@ -26,8 +27,8 @@ class MainMenu:
             self.buttons[button]["sprite"] = pygame.transform.scale(self.buttonImage, self.buttons[button]["size"])
             self.buttons[button]["spriteHovered"] = pygame.transform.scale(self.buttonImageHovered, self.buttons[button]["size"])
         
-        self.acceptSound = pygame.mixer.Sound("assets/NinjaAdventure/Sounds/Menu/Accept.wav")
-        self.changeHoveredSound = pygame.mixer.Sound("assets/NinjaAdventure/Sounds/Menu/Menu1.wav")
+        self.acceptSound = pygame.mixer.Sound(os.path.dirname(__file__) + "/assets/NinjaAdventure/Sounds/Menu/Accept.wav")
+        self.changeHoveredSound = pygame.mixer.Sound(os.path.dirname(__file__) + "/assets/NinjaAdventure/Sounds/Menu/Menu1.wav")
     
     def update(self, joystick):
         keysPressed = pygame.key.get_pressed()

--- a/NPC.py
+++ b/NPC.py
@@ -1,15 +1,16 @@
+import os
 import pygame, math, random
 from globals import *
 
 SQRT2 = math.sqrt(2)
 
-spriteSheetVillager2Idle = pygame.image.load("assets/NinjaAdventure/Actor/Characters/Villager2/SeparateAnim/Idle.png").convert_alpha()
-spriteSheetVillager2Walk = pygame.image.load("assets/NinjaAdventure/Actor/Characters/Villager2/SeparateAnim/Walk.png").convert_alpha()
-spriteSheetVillager3Idle = pygame.image.load("assets/NinjaAdventure/Actor/Characters/Villager3/SeparateAnim/Idle.png").convert_alpha()
-spriteSheetVillager3Walk = pygame.image.load("assets/NinjaAdventure/Actor/Characters/Villager3/SeparateAnim/Walk.png").convert_alpha()
-spriteSheetVillager4Idle = pygame.image.load("assets/NinjaAdventure/Actor/Characters/Villager4/SeparateAnim/Idle.png").convert_alpha()
-spriteSheetVillager4Walk = pygame.image.load("assets/NinjaAdventure/Actor/Characters/Villager4/SeparateAnim/Walk.png").convert_alpha()
-spriteSheetCat = pygame.image.load("assets/NinjaAdventure/Actor/Animals/Cat/SpriteSheet.png").convert_alpha()
+spriteSheetVillager2Idle = pygame.image.load(os.path.dirname(__file__) + "/assets/NinjaAdventure/Actor/Characters/Villager2/SeparateAnim/Idle.png").convert_alpha()
+spriteSheetVillager2Walk = pygame.image.load(os.path.dirname(__file__) + "/assets/NinjaAdventure/Actor/Characters/Villager2/SeparateAnim/Walk.png").convert_alpha()
+spriteSheetVillager3Idle = pygame.image.load(os.path.dirname(__file__) + "/assets/NinjaAdventure/Actor/Characters/Villager3/SeparateAnim/Idle.png").convert_alpha()
+spriteSheetVillager3Walk = pygame.image.load(os.path.dirname(__file__) + "/assets/NinjaAdventure/Actor/Characters/Villager3/SeparateAnim/Walk.png").convert_alpha()
+spriteSheetVillager4Idle = pygame.image.load(os.path.dirname(__file__) + "/assets/NinjaAdventure/Actor/Characters/Villager4/SeparateAnim/Idle.png").convert_alpha()
+spriteSheetVillager4Walk = pygame.image.load(os.path.dirname(__file__) + "/assets/NinjaAdventure/Actor/Characters/Villager4/SeparateAnim/Walk.png").convert_alpha()
+spriteSheetCat = pygame.image.load(os.path.dirname(__file__) + "/assets/NinjaAdventure/Actor/Animals/Cat/SpriteSheet.png").convert_alpha()
 spriteSize = mapTileSize.x
 
 class NPC(pygame.sprite.Sprite):
@@ -31,7 +32,7 @@ class NPC(pygame.sprite.Sprite):
                 "max": 4,
                 "speed": 3
             },
-            "face": pygame.transform.scale(pygame.image.load("assets/NinjaAdventure/Actor/Characters/Villager2/Faceset.png"), (128, 128))
+            "face": pygame.transform.scale(pygame.image.load(os.path.dirname(__file__) + "/assets/NinjaAdventure/Actor/Characters/Villager2/Faceset.png"), (128, 128))
         },
         "Villager3": {
             "idle": {
@@ -50,7 +51,7 @@ class NPC(pygame.sprite.Sprite):
                 "max": 4,
                 "speed": 3
             },
-            "face": pygame.transform.scale(pygame.image.load("assets/NinjaAdventure/Actor/Characters/Villager3/Faceset.png"), (128, 128))
+            "face": pygame.transform.scale(pygame.image.load(os.path.dirname(__file__) + "/assets/NinjaAdventure/Actor/Characters/Villager3/Faceset.png"), (128, 128))
         },
         "Villager4": {
             "idle": {
@@ -69,7 +70,7 @@ class NPC(pygame.sprite.Sprite):
                 "max": 4,
                 "speed": 3
             },
-            "face": pygame.transform.scale(pygame.image.load("assets/NinjaAdventure/Actor/Characters/Villager4/Faceset.png"), (128, 128))
+            "face": pygame.transform.scale(pygame.image.load(os.path.dirname(__file__) + "/assets/NinjaAdventure/Actor/Characters/Villager4/Faceset.png"), (128, 128))
         },
         "Cat": {
             "idle": {
@@ -88,7 +89,7 @@ class NPC(pygame.sprite.Sprite):
                 "max": 2,
                 "speed": 2
             },
-            "face": pygame.transform.scale(pygame.image.load("assets/NinjaAdventure/Actor/Animals/Cat/Faceset.png"), (128, 128))
+            "face": pygame.transform.scale(pygame.image.load(os.path.dirname(__file__) + "/assets/NinjaAdventure/Actor/Animals/Cat/Faceset.png"), (128, 128))
         }
     }
 

--- a/Player.py
+++ b/Player.py
@@ -1,3 +1,4 @@
+import os
 import pygame, math, random
 from inputs import *
 from globals import *
@@ -20,11 +21,11 @@ class Player():
         self.zoom = 1
 
         spriteSize = mapTileSize.x
-        idleSpriteSheet = pygame.image.load("assets/NinjaAdventure/Actor/Characters/GreenNinja/SeparateAnim/Idle.png").convert_alpha()
-        walkSpriteSheet = pygame.image.load("assets/NinjaAdventure/Actor/Characters/GreenNinja/SeparateAnim/Walk.png").convert_alpha()
-        attackSpriteSheet = pygame.image.load("assets/NinjaAdventure/Actor/Characters/GreenNinja/SeparateAnim/Attack.png").convert_alpha()
-        spriteSheetDeath = pygame.image.load("assets/NinjaAdventure/FX/Magic/Circle/SpriteSheetOrange.png").convert_alpha()
-        spriteSheetItem = pygame.image.load("assets/NinjaAdventure/FX/Magic/Spirit/SpriteSheetBlue.png").convert_alpha()
+        idleSpriteSheet = pygame.image.load(os.path.dirname(__file__) + "/assets/NinjaAdventure/Actor/Characters/GreenNinja/SeparateAnim/Idle.png").convert_alpha()
+        walkSpriteSheet = pygame.image.load(os.path.dirname(__file__) + "/assets/NinjaAdventure/Actor/Characters/GreenNinja/SeparateAnim/Walk.png").convert_alpha()
+        attackSpriteSheet = pygame.image.load(os.path.dirname(__file__) + "/assets/NinjaAdventure/Actor/Characters/GreenNinja/SeparateAnim/Attack.png").convert_alpha()
+        spriteSheetDeath = pygame.image.load(os.path.dirname(__file__) + "/assets/NinjaAdventure/FX/Magic/Circle/SpriteSheetOrange.png").convert_alpha()
+        spriteSheetItem = pygame.image.load(os.path.dirname(__file__) + "/assets/NinjaAdventure/FX/Magic/Spirit/SpriteSheetBlue.png").convert_alpha()
         deathSize = 32
         self.animations = {
             "idle": {
@@ -63,7 +64,7 @@ class Player():
         self.direction = "down"
         # self.directionVector = pygame.math.Vector2(0, 1)
 
-        heartSpriteSheet = pygame.image.load("assets/NinjaAdventure/HUD/Heart.png").convert_alpha()
+        heartSpriteSheet = pygame.image.load(os.path.dirname(__file__) + "/assets/NinjaAdventure/HUD/Heart.png").convert_alpha()
         heartSpriteSize = 16
         self.heartSize = (128, 128)
         self.heartSprites = [pygame.transform.scale(heartSpriteSheet.subsurface(pygame.Rect(heartSpriteSize * x, heartSpriteSize * 0, heartSpriteSize, heartSpriteSize)), self.heartSize) for x in range(0, 5)]
@@ -82,14 +83,14 @@ class Player():
         self.weaponOffseX = 5
 
         self.weapons = {
-            "katana": {"sprite": pygame.transform.scale(pygame.image.load("assets/NinjaAdventure/Items/Weapons/Katana/SpriteInHand.png"), (math.floor(size[0] / 2), math.floor(size[1] / 2))),
-                       "spriteMenu": pygame.transform.scale(pygame.image.load("assets/NinjaAdventure/Items/Weapons/Katana/Sprite.png"), self.heartSize),  
+            "katana": {"sprite": pygame.transform.scale(pygame.image.load(os.path.dirname(__file__) + "/assets/NinjaAdventure/Items/Weapons/Katana/SpriteInHand.png"), (math.floor(size[0] / 2), math.floor(size[1] / 2))),
+                       "spriteMenu": pygame.transform.scale(pygame.image.load(os.path.dirname(__file__) + "/assets/NinjaAdventure/Items/Weapons/Katana/Sprite.png"), self.heartSize),  
                        "damage": 1, "knockback": 500, "unlocked": True},
-            "axe": {"sprite": pygame.transform.scale(pygame.image.load("assets/NinjaAdventure/Items/Weapons/Axe/SpriteInHand.png"), (math.floor(size[0] / 2), math.floor(size[1] / 2))),
-                    "spriteMenu": pygame.transform.scale(pygame.image.load("assets/NinjaAdventure/Items/Weapons/Axe/Sprite.png"), self.heartSize), 
+            "axe": {"sprite": pygame.transform.scale(pygame.image.load(os.path.dirname(__file__) + "/assets/NinjaAdventure/Items/Weapons/Axe/SpriteInHand.png"), (math.floor(size[0] / 2), math.floor(size[1] / 2))),
+                    "spriteMenu": pygame.transform.scale(pygame.image.load(os.path.dirname(__file__) + "/assets/NinjaAdventure/Items/Weapons/Axe/Sprite.png"), self.heartSize), 
                     "damage": 2, "knockback": 700, "unlocked": False},
-            "pickaxe": {"sprite": pygame.transform.scale(pygame.image.load("assets/NinjaAdventure/Items/Weapons/Pickaxe/SpriteInHand.png"), (math.floor(size[0] / 2), math.floor(size[1] / 2))),
-                    "spriteMenu": pygame.transform.scale(pygame.image.load("assets/NinjaAdventure/Items/Weapons/Pickaxe/Sprite.png"), self.heartSize), 
+            "pickaxe": {"sprite": pygame.transform.scale(pygame.image.load(os.path.dirname(__file__) + "/assets/NinjaAdventure/Items/Weapons/Pickaxe/SpriteInHand.png"), (math.floor(size[0] / 2), math.floor(size[1] / 2))),
+                    "spriteMenu": pygame.transform.scale(pygame.image.load(os.path.dirname(__file__) + "/assets/NinjaAdventure/Items/Weapons/Pickaxe/Sprite.png"), self.heartSize), 
                     "damage": 1, "knockback": 300, "unlocked": False}
         }
         self.weaponIndex = 0
@@ -121,9 +122,9 @@ class Player():
         self.startDeathTimerOnce = False
 
         self.sounds = {
-            "attack": pygame.mixer.Sound("assets/NinjaAdventure/Sounds/Game/Sword2.wav"),
-            "gameOver": pygame.mixer.Sound("assets/NinjaAdventure/Sounds/Game/GameOver.wav"),
-            "hit": pygame.mixer.Sound("assets/NinjaAdventure/Sounds/Game/Explosion.wav"),
+            "attack": pygame.mixer.Sound(os.path.dirname(__file__) + "/assets/NinjaAdventure/Sounds/Game/Sword2.wav"),
+            "gameOver": pygame.mixer.Sound(os.path.dirname(__file__) + "/assets/NinjaAdventure/Sounds/Game/GameOver.wav"),
+            "hit": pygame.mixer.Sound(os.path.dirname(__file__) + "/assets/NinjaAdventure/Sounds/Game/Explosion.wav"),
         }
         self.sounds["attack"].set_volume(0.3)
         self.sounds["hit"].set_volume(0.3)
@@ -134,28 +135,28 @@ class Player():
         self.talkSpeed = 15
         self.talkSpeedNormal = self.talkSpeed
         self.talkSpeedFast = 120
-        self.talkSounds = [pygame.mixer.Sound("assets/NinjaAdventure/Sounds/Game/Voice4.wav"), 
-                           pygame.mixer.Sound("assets/NinjaAdventure/Sounds/Game/Voice1.wav"),
-                           pygame.mixer.Sound("assets/NinjaAdventure/Sounds/Game/Voice3.wav"),
-                           pygame.mixer.Sound("assets/NinjaAdventure/Sounds/Game/Voice2.wav")]
+        self.talkSounds = [pygame.mixer.Sound(os.path.dirname(__file__) + "/assets/NinjaAdventure/Sounds/Game/Voice4.wav"), 
+                           pygame.mixer.Sound(os.path.dirname(__file__) + "/assets/NinjaAdventure/Sounds/Game/Voice1.wav"),
+                           pygame.mixer.Sound(os.path.dirname(__file__) + "/assets/NinjaAdventure/Sounds/Game/Voice3.wav"),
+                           pygame.mixer.Sound(os.path.dirname(__file__) + "/assets/NinjaAdventure/Sounds/Game/Voice2.wav")]
         self.dialogueText = ""
         self.talkInputOnce = False
         self.NPCFace = -1
         windowSize = pygame.display.get_window_size()
-        self.dialogBox = pygame.image.load("assets/NinjaAdventure/HUD/Dialog/DialogBox.png")
+        self.dialogBox = pygame.image.load(os.path.dirname(__file__) + "/assets/NinjaAdventure/HUD/Dialog/DialogBox.png")
         self.dialogBox = pygame.transform.scale(self.dialogBox, (windowSize[0], self.dialogBox.get_height() + 50))
 
-        plantSpellSpriteSheet = pygame.image.load("assets/NinjaAdventure/FX/Elemental/Plant/SpriteSheet.png")
+        plantSpellSpriteSheet = pygame.image.load(os.path.dirname(__file__) + "/assets/NinjaAdventure/FX/Elemental/Plant/SpriteSheet.png")
         self.items = {
-            "plantSpell": {"spriteMenu": pygame.transform.scale(pygame.image.load("assets/NinjaAdventure/Items/Scroll/ScrollPlant.png"), self.heartSize), "sound": pygame.mixer.Sound("assets/swish-2.wav"), "hitbox": pygame.rect.Rect((0, 0), (size[0] * 2.5, size[1] * 2.5)), "damage": 4, "knockback": 800, "amount": 0, "unlocked": True},
-            "potionHealth": {"spriteMenu": pygame.transform.scale(pygame.image.load("assets/NinjaAdventure/Items/Potion/LifePot.png"), self.heartSize), "healAmount": 4, "amount": 1, "unlocked": True},
-            "coin": {"spriteMenu": pygame.transform.scale(pygame.image.load("assets/NinjaAdventure/Items/Treasure/GoldCoin.png"), self.heartSize), "amount": 0, "unlocked": True}
+            "plantSpell": {"spriteMenu": pygame.transform.scale(pygame.image.load(os.path.dirname(__file__) + "/assets/NinjaAdventure/Items/Scroll/ScrollPlant.png"), self.heartSize), "sound": pygame.mixer.Sound(os.path.dirname(__file__) + "/assets/swish-2.wav"), "hitbox": pygame.rect.Rect((0, 0), (size[0] * 2.5, size[1] * 2.5)), "damage": 4, "knockback": 800, "amount": 0, "unlocked": True},
+            "potionHealth": {"spriteMenu": pygame.transform.scale(pygame.image.load(os.path.dirname(__file__) + "/assets/NinjaAdventure/Items/Potion/LifePot.png"), self.heartSize), "healAmount": 4, "amount": 1, "unlocked": True},
+            "coin": {"spriteMenu": pygame.transform.scale(pygame.image.load(os.path.dirname(__file__) + "/assets/NinjaAdventure/Items/Treasure/GoldCoin.png"), self.heartSize), "amount": 0, "unlocked": True}
         }
         self.equipedItem = "potionHealth"
         self.changeItemOnce = False
         self.itemIndex = 0
         self.itemIndexMax = 3
-        self.itemPickupSound = pygame.mixer.Sound("assets/NinjaAdventure/Sounds/Game/PowerUp1.wav")
+        self.itemPickupSound = pygame.mixer.Sound(os.path.dirname(__file__) + "/assets/NinjaAdventure/Sounds/Game/PowerUp1.wav")
         self.usingItem = False
         self.useItemInputOnce = False
         plantSpellSpriteSize = 28

--- a/globals.py
+++ b/globals.py
@@ -1,12 +1,12 @@
 import pygame, pickle
 import mapLoader
-from os.path import isfile
+from os.path import isfile, dirname
 
 mapTileSize = pygame.math.Vector2(16, 16)
 size = (64, 64)
 
-fontTalk = pygame.font.Font("assets/NinjaAdventure/HUD/Font/NormalFont.ttf", 32)
-fontMenu = pygame.font.Font("assets/NinjaAdventure/HUD/Font/NormalFont.ttf", 128)
+fontTalk = pygame.font.Font(dirname(__file__) + "/assets/NinjaAdventure/HUD/Font/NormalFont.ttf", 32)
+fontMenu = pygame.font.Font(dirname(__file__) + "/assets/NinjaAdventure/HUD/Font/NormalFont.ttf", 128)
 
 savePathPlayer = "saves/player.save"
 savePathWorld = "saves/world.save"

--- a/main.py
+++ b/main.py
@@ -1,12 +1,4 @@
-# Just checking if the packaged game can read assets or savefiles
-# TODO: fix this!
-try:
-    with open("saves/player.save", "rb") as fSavePlayer:
-        print(fSavePlayer)
-        sys.exit(1)
-except FileNotFoundError:
-    print("Error loading save files, the game will most likely fail to load.")
-
+import os
 import pygame, sys
 from pygame.locals import *
 from pytmx.util_pygame import load_pygame
@@ -26,11 +18,11 @@ from Enemy import *
 from Item import *
 from Menu import *
 
-littleChestSprite = pygame.transform.scale(pygame.image.load("assets/NinjaAdventure/Items/Treasure/LittleTreasureChest.png").subsurface(pygame.rect.Rect(0, 0, 16, 16)), (64, 64))
-littleChestOpenSprite = pygame.transform.scale(pygame.image.load("assets/NinjaAdventure/Items/Treasure/LittleTreasureChest.png").subsurface(pygame.rect.Rect(16, 0, 16, 16)), (64, 64))
+littleChestSprite = pygame.transform.scale(pygame.image.load(os.path.dirname(__file__) + "/assets/NinjaAdventure/Items/Treasure/LittleTreasureChest.png").subsurface(pygame.rect.Rect(0, 0, 16, 16)), (64, 64))
+littleChestOpenSprite = pygame.transform.scale(pygame.image.load(os.path.dirname(__file__) + "/assets/NinjaAdventure/Items/Treasure/LittleTreasureChest.png").subsurface(pygame.rect.Rect(16, 0, 16, 16)), (64, 64))
 
 def main():
-    overworldMapPath = "maps/test.tmx"
+    overworldMapPath = os.path.dirname(__file__) + "/maps/test.tmx"
     # mapData = load_pygame(overworldMapPath)
     scaleTo = (64, 64)
     k = pygame.math.Vector2(scaleTo[0] / mapTileSize.x, scaleTo[1] / mapTileSize.y)
@@ -38,10 +30,10 @@ def main():
     # mapSize = (scaleTo[0] * 60, scaleTo[1] * 60)
 
     music = {
-        "adventureBegins": pygame.mixer.Sound("assets/NinjaAdventure/Musics/1 - Adventure Begin.ogg"),
-        "theCave": pygame.mixer.Sound("assets/NinjaAdventure/Musics/2 - The Cave.ogg"),
-        "fight": pygame.mixer.Sound("assets/NinjaAdventure/Musics/17 - Fight.ogg"),
-        "goodTime": pygame.mixer.Sound("assets/NinjaAdventure/Musics/20 - Good Time.ogg"),
+        "adventureBegins": pygame.mixer.Sound(os.path.dirname(__file__) + "/assets/NinjaAdventure/Musics/1 - Adventure Begin.ogg"),
+        "theCave": pygame.mixer.Sound(os.path.dirname(__file__) + "/assets/NinjaAdventure/Musics/2 - The Cave.ogg"),
+        "fight": pygame.mixer.Sound(os.path.dirname(__file__) + "/assets/NinjaAdventure/Musics/17 - Fight.ogg"),
+        "goodTime": pygame.mixer.Sound(os.path.dirname(__file__) + "/assets/NinjaAdventure/Musics/20 - Good Time.ogg"),
     }
     whichMusic = "none"
 
@@ -87,7 +79,7 @@ def main():
                 if area == "Overworld":
                     mapSprites, mapSpritesFront, enemiesGroup, walls, musicAreas, doorAreas, doorDestinations, NPCsGroup, itemsGroup, cuttableGrass, breakableRocks, treasureChests = changeMap(overworldMapPath, scaleTo[0], scaleTo[1], mapTileSize)
                 else:
-                    mapSprites, mapSpritesFront, enemiesGroup, walls, musicAreas, doorAreas, doorDestinations, NPCsGroup, itemsGroup, cuttableGrass, breakableRocks, treasureChests = changeMap("maps/subAreas/" + area + ".tmx", scaleTo[0], scaleTo[1], mapTileSize)
+                    mapSprites, mapSpritesFront, enemiesGroup, walls, musicAreas, doorAreas, doorDestinations, NPCsGroup, itemsGroup, cuttableGrass, breakableRocks, treasureChests = changeMap(os.path.dirname(__file__) + "/maps/subAreas/" + area + ".tmx", scaleTo[0], scaleTo[1], mapTileSize)
 
                 if enemies != -1:
                     enemiesGroup = enemies
@@ -230,7 +222,7 @@ def main():
                 player.rect.topleft = doorDestinations[doorEntered]
                 enemies, items, breakableRocksLoad, treasureChestsLoad, area, worldSave = loadGame(player, Enemy, Item, "Overworld")
             else:
-                mapSprites, mapSpritesFront, enemiesGroup, walls, musicAreas, doorAreas, doorDestinations, NPCsGroup, itemsGroup, cuttableGrass, breakableRocks, treasureChests = changeMap("maps/subAreas/" + doorEntered + ".tmx", scaleTo[0], scaleTo[1], mapTileSize)
+                mapSprites, mapSpritesFront, enemiesGroup, walls, musicAreas, doorAreas, doorDestinations, NPCsGroup, itemsGroup, cuttableGrass, breakableRocks, treasureChests = changeMap(os.path.dirname(__file__) + "/maps/subAreas/" + doorEntered + ".tmx", scaleTo[0], scaleTo[1], mapTileSize)
                 player.rect.topleft = doorDestinations[doorEntered]
                 enemies, items, breakableRocksLoad, treasureChestsLoad, area, worldSave = loadGame(player, Enemy, Item, doorEntered)
 

--- a/main.spec
+++ b/main.spec
@@ -6,26 +6,9 @@ a = Analysis(
     pathex=[],
     binaries=[],
     datas=[
-        # ( "assets/NinjaAdventure/HUD/Font/NormalFont.ttf", "." ),
-        # ( "assets/NinjaAdventure/HUD/Font/NormalFont.ttf", "assets/NinjaAdventure/HUD/Font/" ),
-
-        # ( "assets/**/*.gif", "." ),
-        # ( "assets/**/*.md", "." ),
-        # ( "assets/**/*.ogg", "." ),
-        # ( "assets/**/*.png", "." ),
-        # ( "assets/**/*.ttf", "." ),
-        # ( "assets/**/*.txt", "." ),
-        # ( "assets/**/*.wav", "." ),
-
-        # # ( "assets/", "." ),
-        # # ( "assets/", "assets" ),
-        ( "./assets", "./assets" ),  # TODO:
-        # # ( "assets/", "assets/" ),
-
-        # ( "saves/", "." ),
-        # ( "saves/", "saves" ),
+        ( "./assets", "./assets" ),
+        ( "./maps", "./maps" ),
         ( "./saves", "./saves" ),
-        # ( "saves/", "saves/" ),
     ],
     hiddenimports=[],
     hookspath=[],

--- a/mapLoader.py
+++ b/mapLoader.py
@@ -1,3 +1,4 @@
+import os
 import pygame, math
 from pygame.surface import Surface
 from Enemy import Enemy
@@ -6,9 +7,9 @@ from Item import Item
 from CuttableGrass import CuttableGrass
 from pytmx.util_pygame import load_pygame
 
-coinSprite = pygame.transform.scale(pygame.image.load("assets/NinjaAdventure/Items/Treasure/GoldCoin.png"), (16, 16))
+coinSprite = pygame.transform.scale(pygame.image.load(os.path.dirname(__file__) + "/assets/NinjaAdventure/Items/Treasure/GoldCoin.png"), (16, 16))
 coinHeight = coinSprite.get_height()
-fontPrice = pygame.font.Font("assets/NinjaAdventure/HUD/Font/NormalFont.ttf", 32)
+fontPrice = pygame.font.Font(os.path.dirname(__file__) + "/assets/NinjaAdventure/HUD/Font/NormalFont.ttf", 32)
 priceOffsetY = 32
 priceOffsetX = 8
 


### PR DESCRIPTION
L'objectif est de générer un exécutable avec pyinstaller. Le problème est que les chemins utilisés étaient relatifs à l'endroit depuis lequel la commande "./ninjaSouls" est exécutée. Pour réparer ce problème, on préfixe le chemin des assets par le chemin du répertoire contenant le module courant.

Par exemple, dans main.py, la variable globale `__file__` sera "/home/regis/scripts/ninjaSouls-pygame-experiment/main.py". Donc `os.path.dirname(__file__)` sera
"/home/regis/scripts/ninjaSouls-pygame-experiment".

On peut ensuite générer un fichier exécutable avec "pyinstaller main.spec".

Pour plus d'infos, voir:
https://pyinstaller.org/en/stable/runtime-information.html#using-file